### PR TITLE
fix: _includes/post-date.html whitespace before comma

### DIFF
--- a/_includes/post-date.html
+++ b/_includes/post-date.html
@@ -5,10 +5,10 @@
     {{ page.date | date: "%B" }}
     {% case d %}
       {% when '1' or '21' or '31' %}{{ d }}st
-      {% when '2' or '22' %}{{ d }}nd
-      {% when '3' or '23' %}{{ d }}rd
-      {% else %}{{ d }}th
-    {% endcase %},
+      {%- when '2' or '22' %}{{ d }}nd
+      {%- when '3' or '23' %}{{ d }}rd
+      {%- else %}{{ d }}th
+    {%- endcase %},
     {{ page.date | date: "%Y" }}
   </time>
 


### PR DESCRIPTION
Removes the stray space before the comma in post dates ("August 9th , 2026") by adding Liquid whitespace-control to the ordinal case block.